### PR TITLE
Update aws_checksums_jll to version 0.2.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsChecksums"
 uuid = "332a3e40-df62-419b-9f04-2cb73588ccaf"
-version = "1.1.0"
+version = "1.1.1"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -11,7 +11,7 @@ aws_checksums_jll = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
 Aqua = "0.7"
 CEnum = "0.5"
 LibAwsCommon = "1.2"
-aws_checksums_jll = "=0.1.18"
+aws_checksums_jll = "=0.2.3"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -8,4 +8,4 @@ aws_checksums_jll = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_checksums_jll = "=0.1.18"
+aws_checksums_jll = "=0.2.3"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,30 +1,86 @@
 using CEnum
 
 """
-    aws_checksums_crc32(input, length, previousCrc32)
+    aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32(const uint8_t *input, int length, uint32_t previous_crc32);
 ```
 """
-function aws_checksums_crc32(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32)
 end
 
 """
-    aws_checksums_crc32c(input, length, previousCrc32)
+    aws_checksums_crc32_ex(input, length, previous_crc32)
+
+The entry point function to perform a CRC32 (Ethernet, gzip) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32_ex(const uint8_t *input, size_t length, uint32_t previous_crc32);
+```
+"""
+function aws_checksums_crc32_ex(input, length, previous_crc32)
+    ccall((:aws_checksums_crc32_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32)
+end
+
+"""
+    aws_checksums_crc32c(input, length, previous_crc32c)
 
 The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
 
 ### Prototype
 ```c
-uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previousCrc32);
+uint32_t aws_checksums_crc32c(const uint8_t *input, int length, uint32_t previous_crc32c);
 ```
 """
-function aws_checksums_crc32c(input, length, previousCrc32)
-    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previousCrc32)
+function aws_checksums_crc32c(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c, libaws_checksums), UInt32, (Ptr{UInt8}, Cint, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc32c_ex(input, length, previous_crc32c)
+
+The entry point function to perform a Castagnoli CRC32c (iSCSI) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.
+
+### Prototype
+```c
+uint32_t aws_checksums_crc32c_ex(const uint8_t *input, size_t length, uint32_t previous_crc32c);
+```
+"""
+function aws_checksums_crc32c_ex(input, length, previous_crc32c)
+    ccall((:aws_checksums_crc32c_ex, libaws_checksums), UInt32, (Ptr{UInt8}, Csize_t, UInt32), input, length, previous_crc32c)
+end
+
+"""
+    aws_checksums_crc64nvme(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme(const uint8_t *input, int length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme, libaws_checksums), UInt64, (Ptr{UInt8}, Cint, UInt64), input, length, previous_crc64)
+end
+
+"""
+    aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+
+The entry point function to perform a CRC64-NVME (a.k.a. CRC64-Rocksoft) computation. Supports buffer lengths up to size\\_t max. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc64 parameter as an initial value unless continuing to update a running crc in a subsequent call. There are many variants of CRC64 algorithms. This CRC64 variant is bit-reflected (based on the non bit-reflected polynomial 0xad93d23594c93659) and inverts the CRC input and output bits.
+
+### Prototype
+```c
+uint64_t aws_checksums_crc64nvme_ex(const uint8_t *input, size_t length, uint64_t previous_crc64);
+```
+"""
+function aws_checksums_crc64nvme_ex(input, length, previous_crc64)
+    ccall((:aws_checksums_crc64nvme_ex, libaws_checksums), UInt64, (Ptr{UInt8}, Csize_t, UInt64), input, length, previous_crc64)
 end
 


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_checksums_jll** to version **0.2.3**
- Updated **JuliaServices/LibAwsChecksums.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings