### PR TITLE
Update aws_checksums_jll to version 0.2.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LibAwsChecksums"
 uuid = "332a3e40-df62-419b-9f04-2cb73588ccaf"
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -11,7 +11,7 @@ aws_checksums_jll = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
 Aqua = "0.7"
 CEnum = "0.5"
 LibAwsCommon = "1.2"
-aws_checksums_jll = "=0.2.3"
+aws_checksums_jll = "=0.2.5"
 julia = "1.6"
 
 [extras]

--- a/gen/Project.toml
+++ b/gen/Project.toml
@@ -8,4 +8,4 @@ aws_checksums_jll = "b2a88e68-78e7-5e94-8c20-c02986ec140e"
 [compat]
 Clang = "0.18.3"
 JLLPrefixes = "0.3"
-aws_checksums_jll = "=0.2.3"
+aws_checksums_jll = "=0.2.5"

--- a/lib/aarch64-apple-darwin20.jl
+++ b/lib/aarch64-apple-darwin20.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/aarch64-linux-gnu.jl
+++ b/lib/aarch64-linux-gnu.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/aarch64-linux-musl.jl
+++ b/lib/aarch64-linux-musl.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/armv7l-linux-gnueabihf.jl
+++ b/lib/armv7l-linux-gnueabihf.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/armv7l-linux-musleabihf.jl
+++ b/lib/armv7l-linux-musleabihf.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/i686-linux-gnu.jl
+++ b/lib/i686-linux-gnu.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/i686-linux-musl.jl
+++ b/lib/i686-linux-musl.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/powerpc64le-linux-gnu.jl
+++ b/lib/powerpc64le-linux-gnu.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/x86_64-apple-darwin14.jl
+++ b/lib/x86_64-apple-darwin14.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/x86_64-linux-gnu.jl
+++ b/lib/x86_64-linux-gnu.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/x86_64-linux-musl.jl
+++ b/lib/x86_64-linux-musl.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/x86_64-unknown-freebsd13.2.jl
+++ b/lib/x86_64-unknown-freebsd13.2.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.

--- a/lib/x86_64-w64-mingw32.jl
+++ b/lib/x86_64-w64-mingw32.jl
@@ -1,6 +1,34 @@
 using CEnum
 
 """
+    aws_checksums_library_init(allocator)
+
+Initializes internal data structures used by aws-checksums. MUST be called before using any functionality in aws-checksums. Note: historically aws-checksums lazily initialized stuff and things worked without init. However, DO NOT rely on that behavior and explicitly call init instead.
+
+### Prototype
+```c
+void aws_checksums_library_init(struct aws_allocator *allocator);
+```
+"""
+function aws_checksums_library_init(allocator)
+    ccall((:aws_checksums_library_init, libaws_checksums), Cvoid, (Ptr{Cvoid},), allocator)
+end
+
+"""
+    aws_checksums_library_clean_up()
+
+Shuts down the internal data structures used by aws-checksums.
+
+### Prototype
+```c
+void aws_checksums_library_clean_up(void);
+```
+"""
+function aws_checksums_library_clean_up()
+    ccall((:aws_checksums_library_clean_up, libaws_checksums), Cvoid, ())
+end
+
+"""
     aws_checksums_crc32(input, length, previous_crc32)
 
 The entry point function to perform a CRC32 (Ethernet, gzip) computation. Selects a suitable implementation based on hardware capabilities. Pass 0 in the previousCrc32 parameter as an initial value unless continuing to update a running crc in a subsequent call.


### PR DESCRIPTION
This PR updates the JLL dependency and regenerates bindings automatically.

- Updated **aws_checksums_jll** to version **0.2.5**
- Updated **JuliaServices/LibAwsChecksums.jl** version number
- **Bindings regeneration:**
  - ✅ Updated bindings